### PR TITLE
Refactoring the variable name 'ionisation' to be 'charge' in the

### DIFF
--- a/cherab/openadas/install.py
+++ b/cherab/openadas/install.py
@@ -167,14 +167,14 @@ def install_adf11prc(element, file_path, download=False, repository_path=None, a
     repository.update_cx_power_rates(rate, repository_path)
 
 
-def install_adf12(donor_ion, donor_metastable, receiver_ion, receiver_ionisation, file_path, download=False, repository_path=None, adas_path=None):
+def install_adf12(donor_ion, donor_metastable, receiver_ion, receiver_charge, file_path, download=False, repository_path=None, adas_path=None):
     """
     Adds the rates in the ADF12 file to the repository.
 
     :param donor_ion: The donor ion element described by the rate file.
     :param donor_metastable: The donor ion metastable level.
     :param receiver_ion: The receiver ion element described by the rate file.
-    :param receiver_ionisation: The receiver ion ionisation level described by the rate file.
+    :param receiver_charge: The receiver ion ionisation level described by the rate file.
     :param file_path: Path relative to ADAS root.
     :param download: Attempt to download file if not present (Default=True).
     :param repository_path: Path to the repository in which to install the rates (optional).
@@ -187,7 +187,7 @@ def install_adf12(donor_ion, donor_metastable, receiver_ion, receiver_ionisation
         raise ValueError('Could not locate the specified ADAS file.')
 
     # decode file and write out rates
-    rates = parse_adf12(donor_ion, donor_metastable, receiver_ion, receiver_ionisation, path)
+    rates = parse_adf12(donor_ion, donor_metastable, receiver_ion, receiver_charge, path)
     repository.update_beam_cx_rates(rates, repository_path)
 
 
@@ -214,7 +214,7 @@ def install_adf15(element, ionisation, file_path, download=False, repository_pat
     repository.update_wavelengths(wavelengths, repository_path)
 
 
-def install_adf21(beam_species, target_ion, target_ionisation, file_path, download=False, repository_path=None, adas_path=None):
+def install_adf21(beam_species, target_ion, target_charge, file_path, download=False, repository_path=None, adas_path=None):
     # """
     # Adds the rate defined in an ADF21 file to the repository.
     #
@@ -230,11 +230,11 @@ def install_adf21(beam_species, target_ion, target_ionisation, file_path, downlo
         raise ValueError('Could not locate the specified ADAS file.')
 
     # # decode file and write out rates
-    rate = parse_adf21(beam_species, target_ion, target_ionisation, path)
+    rate = parse_adf21(beam_species, target_ion, target_charge, path)
     repository.update_beam_stopping_rates(rate, repository_path)
 
 
-def install_adf22bmp(beam_species, beam_metastable, target_ion, target_ionisation, file_path, download=False, repository_path=None, adas_path=None):
+def install_adf22bmp(beam_species, beam_metastable, target_ion, target_charge, file_path, download=False, repository_path=None, adas_path=None):
     pass
     # """
     # Adds the rate defined in an ADF21 file to the repository.
@@ -251,11 +251,11 @@ def install_adf22bmp(beam_species, beam_metastable, target_ion, target_ionisatio
         raise ValueError('Could not locate the specified ADAS file.')
 
     # # decode file and write out rates
-    rate = parse_adf22bmp(beam_species, beam_metastable, target_ion, target_ionisation, path)
+    rate = parse_adf22bmp(beam_species, beam_metastable, target_ion, target_charge, path)
     repository.update_beam_population_rates(rate, repository_path)
 
 
-def install_adf22bme(beam_species, target_ion, target_ionisation, transition, file_path, download=False, repository_path=None, adas_path=None):
+def install_adf22bme(beam_species, target_ion, target_charge, transition, file_path, download=False, repository_path=None, adas_path=None):
     pass
     # """
     # Adds the rate defined in an ADF21 file to the repository.
@@ -272,7 +272,7 @@ def install_adf22bme(beam_species, target_ion, target_ionisation, transition, fi
         raise ValueError('Could not locate the specified ADAS file.')
 
     # # decode file and write out rates
-    rate = parse_adf22bme(beam_species, target_ion, target_ionisation, transition, path)
+    rate = parse_adf22bme(beam_species, target_ion, target_charge, transition, path)
     repository.update_beam_emission_rates(rate, repository_path)
 
 

--- a/cherab/openadas/openadas.py
+++ b/cherab/openadas/openadas.py
@@ -44,25 +44,25 @@ class OpenADAS(AtomicData):
     def data_path(self):
         return self._data_path
 
-    def wavelength(self, ion, ionisation, transition):
+    def wavelength(self, ion, charge, transition):
         """
         :param ion: Element object defining the ion type.
-        :param ionisation: Ionisation level of the ion.
+        :param charge: Charge state of the ion.
         :param transition: Tuple containing (initial level, final level)
         :return: Wavelength in nanometers.
         """
 
         if isinstance(ion, Isotope):
             ion = ion.element
-        return repository.get_wavelength(ion, ionisation, transition)
+        return repository.get_wavelength(ion, charge, transition)
 
-    def ionisation_rate(self, ion, ionisation):
+    def ionisation_rate(self, ion, charge):
 
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
-            data = repository.get_ionisation_rate(ion, ionisation)
+            data = repository.get_ionisation_rate(ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -71,13 +71,13 @@ class OpenADAS(AtomicData):
 
         return IonisationRate(data, extrapolate=self._permit_extrapolation)
 
-    def recombination_rate(self, ion, ionisation):
+    def recombination_rate(self, ion, charge):
 
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
-            data = repository.get_recombination_rate(ion, ionisation)
+            data = repository.get_recombination_rate(ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -86,12 +86,12 @@ class OpenADAS(AtomicData):
 
         return RecombinationRate(data, extrapolate=self._permit_extrapolation)
 
-    def beam_cx_pec(self, donor_ion, receiver_ion, receiver_ionisation, transition):
+    def beam_cx_pec(self, donor_ion, receiver_ion, receiver_charge, transition):
         """
 
         :param donor_ion:
         :param receiver_ion:
-        :param receiver_ionisation:
+        :param receiver_charge:
         :param transition:
         :return:
         """
@@ -105,8 +105,8 @@ class OpenADAS(AtomicData):
 
         try:
             # read data
-            wavelength = repository.get_wavelength(receiver_ion, receiver_ionisation - 1, transition)
-            data = repository.get_beam_cx_rates(donor_ion, receiver_ion, receiver_ionisation, transition)
+            wavelength = repository.get_wavelength(receiver_ion, receiver_charge - 1, transition)
+            data = repository.get_beam_cx_rates(donor_ion, receiver_ion, receiver_charge, transition)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -119,12 +119,12 @@ class OpenADAS(AtomicData):
             rates.append(BeamCXPEC(donor_metastable, wavelength, rate_data, extrapolate=self._permit_extrapolation))
         return rates
 
-    def beam_stopping_rate(self, beam_ion, plasma_ion, ionisation):
+    def beam_stopping_rate(self, beam_ion, plasma_ion, charge):
         """
 
         :param beam_ion:
         :param plasma_ion:
-        :param ionisation:
+        :param charge:
         :return:
         """
 
@@ -137,7 +137,7 @@ class OpenADAS(AtomicData):
 
         try:
             # locate data file
-            data = repository.get_beam_stopping_rate(beam_ion, plasma_ion, ionisation)
+            data = repository.get_beam_stopping_rate(beam_ion, plasma_ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -147,13 +147,13 @@ class OpenADAS(AtomicData):
         # load and interpolate data
         return BeamStoppingRate(data, extrapolate=self._permit_extrapolation)
 
-    def beam_population_rate(self, beam_ion, metastable, plasma_ion, ionisation):
+    def beam_population_rate(self, beam_ion, metastable, plasma_ion, charge):
         """
 
         :param beam_ion:
         :param metastable:
         :param plasma_ion:
-        :param ionisation:
+        :param charge:
         :return:
         """
 
@@ -166,7 +166,7 @@ class OpenADAS(AtomicData):
 
         try:
             # locate data file
-            data = repository.get_beam_population_rate(beam_ion, metastable, plasma_ion, ionisation)
+            data = repository.get_beam_population_rate(beam_ion, metastable, plasma_ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -176,12 +176,12 @@ class OpenADAS(AtomicData):
         # load and interpolate data
         return BeamPopulationRate(data, extrapolate=self._permit_extrapolation)
 
-    def beam_emission_pec(self, beam_ion, plasma_ion, ionisation, transition):
+    def beam_emission_pec(self, beam_ion, plasma_ion, charge, transition):
         """
 
         :param beam_ion:
         :param plasma_ion:
-        :param ionisation:
+        :param charge:
         :param transition:
         :return:
         """
@@ -195,8 +195,8 @@ class OpenADAS(AtomicData):
 
         try:
             # locate data file
-            data = repository.get_beam_emission_rate(beam_ion, plasma_ion, ionisation, transition)
-            wavelength = repository.get_wavelength(plasma_ion, ionisation - 1, transition)
+            data = repository.get_beam_emission_rate(beam_ion, plasma_ion, charge, transition)
+            wavelength = repository.get_wavelength(plasma_ion, charge - 1, transition)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -206,11 +206,11 @@ class OpenADAS(AtomicData):
         # load and interpolate data
         return BeamEmissionPEC(data, wavelength, extrapolate=self._permit_extrapolation)
 
-    def impact_excitation_pec(self, ion, ionisation, transition):
+    def impact_excitation_pec(self, ion, charge, transition):
         """
 
         :param ion:
-        :param ionisation:
+        :param charge:
         :param transition:
         :return:
         """
@@ -219,8 +219,8 @@ class OpenADAS(AtomicData):
             ion = ion.element
 
         try:
-            wavelength = repository.get_wavelength(ion, ionisation, transition)
-            data = repository.get_pec_excitation_rate(ion, ionisation, transition)
+            wavelength = repository.get_wavelength(ion, charge, transition)
+            data = repository.get_pec_excitation_rate(ion, charge, transition)
 
         except RuntimeError:
             if self._missing_rates_return_null:
@@ -229,11 +229,11 @@ class OpenADAS(AtomicData):
 
         return ImpactExcitationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
 
-    def recombination_pec(self, ion, ionisation, transition):
+    def recombination_pec(self, ion, charge, transition):
         """
 
         :param ion:
-        :param ionisation:
+        :param charge:
         :param transition:
         :return:
         """
@@ -242,8 +242,8 @@ class OpenADAS(AtomicData):
             ion = ion.element
 
         try:
-            wavelength = repository.get_wavelength(ion, ionisation, transition)
-            data = repository.get_pec_recombination_rate(ion, ionisation, transition)
+            wavelength = repository.get_wavelength(ion, charge, transition)
+            data = repository.get_pec_recombination_rate(ion, charge, transition)
 
         except (FileNotFoundError, KeyError):
             if self._missing_rates_return_null:
@@ -252,49 +252,49 @@ class OpenADAS(AtomicData):
 
         return RecombinationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
 
-    def line_radiated_power_rate(self, ion, ionisation):
+    def line_radiated_power_rate(self, ion, charge):
 
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
-            data = repository.get_line_radiated_power_rate(ion, ionisation)
+            data = repository.get_line_radiated_power_rate(ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
                 return NullIonisationRate()
             raise
 
-        return LineRadiationPower(ion, ionisation, data, extrapolate=self._permit_extrapolation)
+        return LineRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation)
 
-    def continuum_radiated_power_rate(self, ion, ionisation):
+    def continuum_radiated_power_rate(self, ion, charge):
 
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
-            data = repository.get_continuum_radiated_power_rate(ion, ionisation)
+            data = repository.get_continuum_radiated_power_rate(ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
                 return NullIonisationRate()
             raise
 
-        return ContinuumPower(ion, ionisation, data, extrapolate=self._permit_extrapolation)
+        return ContinuumPower(ion, charge, data, extrapolate=self._permit_extrapolation)
 
-    def cx_radiated_power_rate(self, ion, ionisation):
+    def cx_radiated_power_rate(self, ion, charge):
 
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
-            data = repository.get_cx_radiated_power_rate(ion, ionisation)
+            data = repository.get_cx_radiated_power_rate(ion, charge)
 
         except RuntimeError:
             if self._missing_rates_return_null:
                 return NullIonisationRate()
             raise
 
-        return CXRadiationPower(ion, ionisation, data, extrapolate=self._permit_extrapolation)
+        return CXRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation)
 
 

--- a/cherab/openadas/parse/adf12.py
+++ b/cherab/openadas/parse/adf12.py
@@ -21,14 +21,14 @@ from cherab.core.utility.conversion import Cm3ToM3, PerCm3ToPerM3
 from .utility import readvalues
 
 
-def parse_adf12(donor_ion, donor_metastable, receiver_ion, receiver_ionisation, adf_file_path):
+def parse_adf12(donor_ion, donor_metastable, receiver_ion, receiver_charge, adf_file_path):
     """
     Opens and parses ADAS ADF12 data files.
 
     :param donor_ion: The donor ion element described by the rate file.
     :param donor_metastable: The donor ion metastable level.
     :param receiver_ion: The receiver ion element described by the rate file.
-    :param receiver_ionisation: The receiver ion ionisation level described by the rate file.
+    :param receiver_charge: The receiver ion charge state described by the rate file.
     :param adf_file_path: Path to ADF15 file from ADAS root.
     :return: Dictionary containing rates.
     """
@@ -44,7 +44,7 @@ def parse_adf12(donor_ion, donor_metastable, receiver_ion, receiver_ionisation, 
             transition, rate = _parse_block(file)
 
             # add to repository update dictionary, converting density from cm^-3 to m^-3
-            rates[donor_ion][receiver_ion][receiver_ionisation][transition][donor_metastable] = {
+            rates[donor_ion][receiver_ion][receiver_charge][transition][donor_metastable] = {
                 'eb': np.array(rate['ENER'], np.float64),
                 'ti': np.array(rate['TIEV'], np.float64),
                 'ni': PerCm3ToPerM3.to(np.array(rate['DENSI'], np.float64)),

--- a/cherab/openadas/parse/adf21.py
+++ b/cherab/openadas/parse/adf21.py
@@ -20,19 +20,19 @@ from cherab.core.utility import RecursiveDict
 from .utility import parse_adas2x_rate
 
 
-def parse_adf21(beam_species, target_ion, target_ionisation, adf_file_path):
+def parse_adf21(beam_species, target_ion, target_charge, adf_file_path):
     """
     Opens and parses ADAS ADF21 data files.
 
     :param beam_species: Element object describing the beam species.
     :param target_ion: Element object describing the target ion species.
-    :param target_ionisation: Ionisation level of the target species.
+    :param target_charge: Ionisation level of the target species.
     :param adf_file_path: Path to ADF15 file from ADAS root.
     :return: Dictionary containing rates.
     """
 
     rate = RecursiveDict()
     with open(adf_file_path, 'r') as file:
-        rate[beam_species][target_ion][target_ionisation] = parse_adas2x_rate(file)
+        rate[beam_species][target_ion][target_charge] = parse_adas2x_rate(file)
     return rate
 

--- a/cherab/openadas/parse/adf22.py
+++ b/cherab/openadas/parse/adf22.py
@@ -20,31 +20,31 @@ from cherab.core.utility import RecursiveDict
 from .utility import parse_adas2x_rate
 
 
-def parse_adf22bmp(beam_species, beam_metastable, target_ion, target_ionisation, adf_file_path):
+def parse_adf22bmp(beam_species, beam_metastable, target_ion, target_charge, adf_file_path):
     """
     Opens and parses ADAS ADF22 BMP data files.
 
     :param beam_species: Element object describing the beam species.
     :param beam_metastable: The metastable level of the beam species.
     :param target_ion: Element object describing the target ion species.
-    :param target_ionisation: Ionisation level of the target species.
+    :param target_charge: Charge state of the target species.
     :param adf_file_path: Path to ADF15 file from ADAS root.
     :return: Dictionary containing rates.
     """
 
     rate = RecursiveDict()
     with open(adf_file_path, 'r') as file:
-        rate[beam_species][beam_metastable][target_ion][target_ionisation] = parse_adas2x_rate(file)
+        rate[beam_species][beam_metastable][target_ion][target_charge] = parse_adas2x_rate(file)
     return rate
 
 
-def parse_adf22bme(beam_species, target_ion, target_ionisation, transition, adf_file_path):
+def parse_adf22bme(beam_species, target_ion, target_charge, transition, adf_file_path):
     """
     Opens and parses ADAS ADF22 BME data files.
 
     :param beam_species: Element object describing the beam species.
     :param target_ion: Element object describing the target ion species.
-    :param target_ionisation: Ionisation level of the target species.
+    :param target_charge: Charge state of the target species.
     :param transition: Atomic transition tuple (upper level, lower level).
     :param adf_file_path: Path to ADF15 file from ADAS root.
     :return: Dictionary containing rates.
@@ -52,5 +52,5 @@ def parse_adf22bme(beam_species, target_ion, target_ionisation, transition, adf_
 
     rate = RecursiveDict()
     with open(adf_file_path, 'r') as file:
-        rate[beam_species][target_ion][target_ionisation][transition] = parse_adas2x_rate(file)
+        rate[beam_species][target_ion][target_charge][transition] = parse_adas2x_rate(file)
     return rate

--- a/cherab/openadas/repository/beam/population.py
+++ b/cherab/openadas/repository/beam/population.py
@@ -20,21 +20,21 @@ import os
 import json
 import numpy as np
 from cherab.core.atomic import Element
-from ..utility import DEFAULT_REPOSITORY_PATH, valid_ionisation
+from ..utility import DEFAULT_REPOSITORY_PATH, valid_charge
 
 """
 Utilities for managing the local rate repository - beam population section.
 """
 
 
-def add_beam_population_rate(beam_species, beam_metastable, target_ion, target_ionisation, rate, repository_path=None):
+def add_beam_population_rate(beam_species, beam_metastable, target_ion, target_charge, rate, repository_path=None):
     """
     Adds a single beam population rate to the repository.
 
     :param beam_species:
     :param beam_metastable:
     :param target_ion:
-    :param target_ionisation:
+    :param target_charge:
     :param rate:
     :return:
     """
@@ -51,8 +51,8 @@ def add_beam_population_rate(beam_species, beam_metastable, target_ion, target_i
     if not isinstance(target_ion, Element):
         raise TypeError('The beam_species must be an Element object.')
 
-    if not valid_ionisation(target_ion, target_ionisation):
-        raise ValueError('Ionisation level is larger than the number of protons in the target ion.')
+    if not valid_charge(target_ion, target_charge):
+        raise ValueError('Charge state is larger than the number of protons in the target ion.')
 
     # sanitise and validate rate data
     e = np.array(rate['e'], np.float64)
@@ -88,7 +88,7 @@ def add_beam_population_rate(beam_species, beam_metastable, target_ion, target_i
     rate['tref'] = float(rate['tref'])
     rate['sref'] = float(rate['sref'])
 
-    path = os.path.join(repository_path, 'beam/population/{}/{}/{}/{}.json'.format(beam_species.symbol.lower(), beam_metastable, target_ion.symbol.lower(), target_ionisation))
+    path = os.path.join(repository_path, 'beam/population/{}/{}/{}/{}.json'.format(beam_species.symbol.lower(), beam_metastable, target_ion.symbol.lower(), target_charge))
 
     # create directory structure if missing
     directory = os.path.dirname(path)
@@ -104,28 +104,28 @@ def update_beam_population_rates(rates, repository_path=None):
     """
     Beam population rate file structure
 
-    /beam/population/<beam species>/<beam metastable>/<target ion>/<target_ionisation>.json
+    /beam/population/<beam species>/<beam metastable>/<target ion>/<target_charge>.json
 
     Each json file contains a single rate, so it can simply be replaced.
     """
 
     for beam_species, beam_metastables in rates.items():
         for beam_metastable, target_ions in beam_metastables.items():
-            for target_ion, target_ionisations in target_ions.items():
-                for target_ionisation, rate in target_ionisations.items():
-                    add_beam_population_rate(beam_species, beam_metastable, target_ion, target_ionisation, rate, repository_path)
+            for target_ion, target_charge_states in target_ions.items():
+                for target_charge, rate in target_charge_states.items():
+                    add_beam_population_rate(beam_species, beam_metastable, target_ion, target_charge, rate, repository_path)
 
 
-def get_beam_population_rate(beam_species, beam_metastable, target_ion, target_ionisation, repository_path=None):
+def get_beam_population_rate(beam_species, beam_metastable, target_ion, target_charge, repository_path=None):
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
-    path = os.path.join(repository_path, 'beam/population/{}/{}/{}/{}.json'.format(beam_species.symbol.lower(), beam_metastable, target_ion.symbol.lower(), target_ionisation))
+    path = os.path.join(repository_path, 'beam/population/{}/{}/{}/{}.json'.format(beam_species.symbol.lower(), beam_metastable, target_ion.symbol.lower(), target_charge))
     try:
         with open(path, 'r') as f:
             rate = json.load(f)
     except FileNotFoundError:
-        raise RuntimeError('Requested beam population rate (beam species={}, beam metastable={}, target ion={}, target ionisation={})'
-                           ' is not available.'.format(beam_species.symbol, beam_metastable, target_ion.symbol, target_ionisation))
+        raise RuntimeError('Requested beam population rate (beam species={}, beam metastable={}, target ion={}, target charge={})'
+                           ' is not available.'.format(beam_species.symbol, beam_metastable, target_ion.symbol, target_charge))
 
     # convert lists to numpy arrays
     rate['e'] = np.array(rate['e'], np.float64)

--- a/cherab/openadas/repository/beam/stopping.py
+++ b/cherab/openadas/repository/beam/stopping.py
@@ -20,20 +20,20 @@ import os
 import json
 import numpy as np
 from cherab.core.atomic import Element
-from ..utility import DEFAULT_REPOSITORY_PATH, valid_ionisation
+from ..utility import DEFAULT_REPOSITORY_PATH, valid_charge
 
 """
 Utilities for managing the local rate repository - beam stopping section.
 """
 
 
-def add_beam_stopping_rate(beam_species, target_ion, target_ionisation, rate, repository_path=None):
+def add_beam_stopping_rate(beam_species, target_ion, target_charge, rate, repository_path=None):
     """
     Adds a single beam stopping/excitation rate to the repository.
 
     :param beam_species:
     :param target_ion:
-    :param target_ionisation:
+    :param target_charge:
     :param rate:
     :return:
     """
@@ -47,8 +47,8 @@ def add_beam_stopping_rate(beam_species, target_ion, target_ionisation, rate, re
     if not isinstance(target_ion, Element):
         raise TypeError('The beam_species must be an Element object.')
 
-    if not valid_ionisation(target_ion, target_ionisation):
-        raise ValueError('Ionisation level is larger than the number of protons in the target ion.')
+    if not valid_charge(target_ion, target_charge):
+        raise ValueError('Charge state is larger than the number of protons in the target ion.')
 
     # sanitise and validate rate data
     e = np.array(rate['e'], np.float64)
@@ -84,7 +84,7 @@ def add_beam_stopping_rate(beam_species, target_ion, target_ionisation, rate, re
     rate['tref'] = float(rate['tref'])
     rate['sref'] = float(rate['sref'])
 
-    path = os.path.join(repository_path, 'beam/stopping/{}/{}/{}.json'.format(beam_species.symbol.lower(), target_ion.symbol.lower(), target_ionisation))
+    path = os.path.join(repository_path, 'beam/stopping/{}/{}/{}.json'.format(beam_species.symbol.lower(), target_ion.symbol.lower(), target_charge))
 
     # create directory structure if missing
     directory = os.path.dirname(path)
@@ -100,27 +100,27 @@ def update_beam_stopping_rates(rates, repository_path=None):
     """
     Beam stopping rate file structure
 
-    /beam/stopping/<beam species>/<target ion>/<target_ionisation>.json
+    /beam/stopping/<beam species>/<target ion>/<target_charge>.json
 
     Each json file contains a single rate, so it can simply be replaced.
     """
 
     for beam_species, target_ions in rates.items():
-        for target_ion, target_ionisations in target_ions.items():
-            for target_ionisation, rate in target_ionisations.items():
-                add_beam_stopping_rate(beam_species, target_ion, target_ionisation, rate, repository_path)
+        for target_ion, target_charge_states in target_ions.items():
+            for target_charge, rate in target_charge_states.items():
+                add_beam_stopping_rate(beam_species, target_ion, target_charge, rate, repository_path)
 
 
-def get_beam_stopping_rate(beam_species, target_ion, target_ionisation, repository_path=None):
+def get_beam_stopping_rate(beam_species, target_ion, target_charge, repository_path=None):
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
-    path = os.path.join(repository_path, 'beam/stopping/{}/{}/{}.json'.format(beam_species.symbol.lower(), target_ion.symbol.lower(), target_ionisation))
+    path = os.path.join(repository_path, 'beam/stopping/{}/{}/{}.json'.format(beam_species.symbol.lower(), target_ion.symbol.lower(), target_charge))
     try:
         with open(path, 'r') as f:
             rate = json.load(f)
     except FileNotFoundError:
-        raise RuntimeError('Requested beam stopping rate (beam species={}, target ion={}, target ionisation={})'
-                           ' is not available.'.format(beam_species.symbol, target_ion.symbol, target_ionisation))
+        raise RuntimeError('Requested beam stopping rate (beam species={}, target ion={}, target charge={})'
+                           ' is not available.'.format(beam_species.symbol, target_ion.symbol, target_charge))
 
     # convert lists to numpy arrays
     rate['e'] = np.array(rate['e'], np.float64)

--- a/cherab/openadas/repository/radiated_power.py
+++ b/cherab/openadas/repository/radiated_power.py
@@ -24,10 +24,10 @@ import numpy as np
 
 from cherab.core.atomic import Element
 from cherab.core.utility import RecursiveDict
-from .utility import DEFAULT_REPOSITORY_PATH, valid_ionisation
+from .utility import DEFAULT_REPOSITORY_PATH, valid_charge
 
 
-def add_line_power_rate(species, ionisation, rate, repository_path=None):
+def add_line_power_rate(species, charge, rate, repository_path=None):
     """
     Adds a single LineRadiationPower rate to the repository.
 
@@ -40,7 +40,7 @@ def add_line_power_rate(species, ionisation, rate, repository_path=None):
 
     update_line_power_rates({
         species: {
-            ionisation: rate
+            charge: rate
         }
     }, repository_path)
 
@@ -53,7 +53,7 @@ def update_line_power_rates(rates, repository_path=None):
 
     /radiated_power/line/<species>.json
 
-    File contains multiple rates, indexed by ion ionisation.
+    File contains multiple rates, indexed by the ion's charge state.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -69,7 +69,7 @@ def update_line_power_rates(rates, repository_path=None):
         _update_and_write_adf11(species, rate_data, path)
 
 
-def add_continuum_power_rate(species, ionisation, rate, repository_path=None):
+def add_continuum_power_rate(species, charge, rate, repository_path=None):
     """
     Adds a single ContinuumPower rate to the repository.
 
@@ -82,7 +82,7 @@ def add_continuum_power_rate(species, ionisation, rate, repository_path=None):
 
     update_line_power_rates({
         species: {
-            ionisation: rate
+            charge: rate
         }
     }, repository_path)
 
@@ -95,7 +95,7 @@ def update_continuum_power_rates(rates, repository_path=None):
 
     /radiated_power/continuum/<species>.json
 
-    File contains multiple rates, indexed by ion ionisation.
+    File contains multiple rates, indexed by ion's charge state.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -111,7 +111,7 @@ def update_continuum_power_rates(rates, repository_path=None):
         _update_and_write_adf11(species, rate_data, path)
 
 
-def add_cx_power_rate(species, ionisation, rate, repository_path=None):
+def add_cx_power_rate(species, charge, rate, repository_path=None):
     """
     Adds a single CXRadiationPower rate to the repository.
 
@@ -124,7 +124,7 @@ def add_cx_power_rate(species, ionisation, rate, repository_path=None):
 
     update_line_power_rates({
         species: {
-            ionisation: rate
+            charge: rate
         }
     }, repository_path)
 
@@ -137,7 +137,7 @@ def update_cx_power_rates(rates, repository_path=None):
 
     /radiated_power/cx/<species>.json
 
-    File contains multiple rates, indexed by ion ionisation.
+    File contains multiple rates, indexed by ion's charge state.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -162,10 +162,10 @@ def _update_and_write_adf11(species, rate_data, path):
     except FileNotFoundError:
         content = RecursiveDict()
 
-    for ionisation, rates in rate_data.items():
+    for charge, rates in rate_data.items():
 
-        if not valid_ionisation(species, ionisation):
-            raise ValueError('Ionisation level is larger than the number of protons in the specified species.')
+        if not valid_charge(species, charge):
+            raise ValueError('The charge state is larger than the number of protons in the specified species.')
 
         # sanitise and validate rate data
         te = np.array(rates['te'], np.float64)
@@ -182,7 +182,7 @@ def _update_and_write_adf11(species, rate_data, path):
             raise ValueError('Electron temperature, density and rate data arrays have inconsistent sizes.')
 
         # update file content with new rate
-        content[ionisation] = {
+        content[charge] = {
             'te': te.tolist(),
             'ne': ne.tolist(),
             'rate': rate_table.tolist(),
@@ -198,7 +198,7 @@ def _update_and_write_adf11(species, rate_data, path):
             json.dump(content, f, indent=2, sort_keys=True)
 
 
-def get_line_radiated_power_rate(element, ionisation, repository_path=None):
+def get_line_radiated_power_rate(element, charge, repository_path=None):
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -206,12 +206,12 @@ def get_line_radiated_power_rate(element, ionisation, repository_path=None):
     try:
         with open(path, 'r') as f:
             content = json.load(f)
-        d = content[str(ionisation)]
+        d = content[str(charge)]
     except (FileNotFoundError, KeyError):
         print()
         print(path)
-        raise RuntimeError('Requested radiated power rate (element={}, ionisation={})'
-                           ' is not available.'.format(element.symbol, ionisation))
+        raise RuntimeError('Requested radiated power rate (element={}, charge={})'
+                           ' is not available.'.format(element.symbol, charge))
 
     # convert to numpy arrays
     d['ne'] = np.array(d['ne'], np.float64)
@@ -221,7 +221,7 @@ def get_line_radiated_power_rate(element, ionisation, repository_path=None):
     return d
 
 
-def get_continuum_radiated_power_rate(element, ionisation, repository_path=None):
+def get_continuum_radiated_power_rate(element, charge, repository_path=None):
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -229,12 +229,12 @@ def get_continuum_radiated_power_rate(element, ionisation, repository_path=None)
     try:
         with open(path, 'r') as f:
             content = json.load(f)
-        d = content[str(ionisation)]
+        d = content[str(charge)]
     except (FileNotFoundError, KeyError):
         print()
         print(path)
-        raise RuntimeError('Requested radiated power rate (element={}, ionisation={})'
-                           ' is not available.'.format(element.symbol, ionisation))
+        raise RuntimeError('Requested radiated power rate (element={}, charge={})'
+                           ' is not available.'.format(element.symbol, charge))
 
     # convert to numpy arrays
     d['ne'] = np.array(d['ne'], np.float64)
@@ -244,7 +244,7 @@ def get_continuum_radiated_power_rate(element, ionisation, repository_path=None)
     return d
 
 
-def get_cx_radiated_power_rate(element, ionisation, repository_path=None):
+def get_cx_radiated_power_rate(element, charge, repository_path=None):
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -252,12 +252,12 @@ def get_cx_radiated_power_rate(element, ionisation, repository_path=None):
     try:
         with open(path, 'r') as f:
             content = json.load(f)
-        d = content[str(ionisation)]
+        d = content[str(charge)]
     except (FileNotFoundError, KeyError):
         print()
         print(path)
-        raise RuntimeError('Requested radiated power rate (element={}, ionisation={})'
-                           ' is not available.'.format(element.symbol, ionisation))
+        raise RuntimeError('Requested radiated power rate (element={}, charge={})'
+                           ' is not available.'.format(element.symbol, charge))
 
     # convert to numpy arrays
     d['ne'] = np.array(d['ne'], np.float64)

--- a/cherab/openadas/repository/utility.py
+++ b/cherab/openadas/repository/utility.py
@@ -40,14 +40,14 @@ def encode_transition(transition):
     return '{} -> {}'.format(upper, lower)
 
 
-def valid_ionisation(element, ionisation):
+def valid_charge(element, charge):
     """
-    Returns true if the element can be ionised to the specified level.
+    Returns true if the element can be ionised to the specified charge state level.
 
-    :param ionisation: Integer ionisation level.
+    :param charge: Integer charge state.
     :return: True/False.
     """
-    return ionisation <= element.atomic_number
+    return charge <= element.atomic_number
 
 
 


### PR DESCRIPTION
context of an ion. This is to prevent a name class between the
ion's charge state and the atomic process of ionisation.
Fixes #21.